### PR TITLE
Render all columns

### DIFF
--- a/frontend/be-compliant/src/components/questionRow/QuestionRow.tsx
+++ b/frontend/be-compliant/src/components/questionRow/QuestionRow.tsx
@@ -1,35 +1,40 @@
-import { Dispatch, SetStateAction } from "react";
-import { Td, Tr } from "@kvib/react";
-import { Answer } from "../answer/Answer";
-import "./questionRow.css";
-import { formatDateTime } from "../../utils/formatTime";
-import { RecordType } from "../table/Table";
+import { Dispatch, SetStateAction } from 'react'
+import { Td, Tr } from '@kvib/react'
+import { Answer } from '../answer/Answer'
+import './questionRow.css'
+import { formatDateTime } from '../../utils/formatTime'
+import { Fields, RecordType } from '../table/Table'
+import { Field } from '../../hooks/datafetcher'
 
 interface QuestionRowProps {
   record: RecordType;
-  choices: string[] | [];
+  choices: string[];
   setFetchNewAnswers: Dispatch<SetStateAction<boolean>>;
-}
-
-const sanitizeClassName = (name: string) => {
-  if (name?.includes('(') && name?.includes(')')) {
-    return name.replace(/\(|\)/g, '-')
-  }
-  return name
+  tableColumns: Field[];
 }
 
 export const QuestionRow = (props: QuestionRowProps) => {
+  const arrayToString = (list: string[]): string => list.join(', ')
   return (
     <Tr>
-        <Td>{props.record.fields.answer ? formatDateTime(props.record.fields.updated) : ""}</Td>
-        <Td className="question">{props.record.fields.Aktivitiet}</Td>
-        <Td><div className={`circle ${sanitizeClassName(props.record.fields.Pri)}`}>{props.record.fields.Pri}</div></Td>
-        <Td>{props.record.fields.Hvem?.join(", ")}</Td>
+      <Td>{props.record.fields.answer ? formatDateTime(props.record.fields.updated) : ''}</Td>
       <Td className="finished">{props.record.fields.status}</Td>
+
+      {props.tableColumns.map((column: Field, index: number) => {
+
+        const columnKey = column.name as keyof Fields
+        const cellValue = props.record.fields[columnKey]
+        const cellRenderValue = Array.isArray(cellValue) ? arrayToString(cellValue) : cellValue
+
+        return (
+          <Td key={index}>{cellRenderValue}</Td>
+        )
+      })}
+
       <Td className="answer">
         <Answer
           choices={props.choices}
-          answer={props.record.fields.answer ? props.record.fields.answer : ""}
+          answer={props.record.fields.answer ? props.record.fields.answer : ''}
           record={props.record}
           setFetchNewAnswers={props.setFetchNewAnswers}
         />

--- a/frontend/be-compliant/src/components/table/Table.tsx
+++ b/frontend/be-compliant/src/components/table/Table.tsx
@@ -143,6 +143,7 @@ export const MainTableComponent = () => {
                     record={item}
                     choices={choices}
                     setFetchNewAnswers={setFetchNewAnswers}
+                    tableColumns={tableMetaData.fields}
                   />
               ))}
               </Tbody>

--- a/frontend/be-compliant/src/components/table/Table.tsx
+++ b/frontend/be-compliant/src/components/table/Table.tsx
@@ -42,7 +42,7 @@ export type ActiveFilter = {
 export const MainTableComponent = () => {
   const [fetchNewAnswers, setFetchNewAnswers] = useState(true);
   const { answers } = useAnswersFetcher(fetchNewAnswers, setFetchNewAnswers);
-  const { data, dataError, choices } = useMetodeverkFetcher()
+  const { data, dataError, choices, tableMetaData } = useMetodeverkFetcher()
   const [fieldSortedBy, setFieldSortedBy] = useState<keyof Fields>();
   const [combinedData, setCombinedData] = useState<RecordType[]>([])
   const statusFilterOptions = ["Utfylt", "Ikke utfylt"];
@@ -119,7 +119,7 @@ export const MainTableComponent = () => {
       <div>
         {dataError ? (
           <div>{dataError}</div> // Display error if there is any
-        ) : dataToDisplay ? (
+        ) : dataToDisplay && tableMetaData ? (
           <TableContainer>
             <Table
               variant="striped"
@@ -128,12 +128,12 @@ export const MainTableComponent = () => {
             >
               <Thead>
                 <Tr>
-                  <Th>NÅR</Th>
-                  <Th>SPØRSMÅL</Th>
-                  <Th>PRI</Th>
-                  <Th>ANSVARLIG</Th>
-                  <Th>STATUS</Th>
-                  <Th>SVAR</Th>
+                  <Th>Når</Th>
+                  <Th>Status</Th>
+                  {tableMetaData.fields.map((field, index) =>
+                    <Th key={index}>{field.name}</Th>
+                  )}
+                  <Th>Svar</Th>
                 </Tr>
               </Thead>
               <Tbody>

--- a/frontend/be-compliant/src/hooks/datafetcher.ts
+++ b/frontend/be-compliant/src/hooks/datafetcher.ts
@@ -16,7 +16,7 @@ type View = {
 }
 
 
-type Field = {
+export type Field = {
   id: string
   name: string
   type: string
@@ -39,6 +39,7 @@ type Option = {
 export const useMetodeverkFetcher = () => {
     const [data, setData] = useState<RecordType[]>([]);
     const [metadata, setMetadata] = useState<MetaData[]>([]);
+    const [tableMetaData, setTableMetaData] = useState<MetaData>()
     const [dataError, setDataError] = useState<string | null>(null);
     const [choices, setChoices] = useState<string[] | []>([]);
 
@@ -72,6 +73,8 @@ export const useMetodeverkFetcher = () => {
           if (!aktivitetsTable) {
             throw new Error(`Failed to fetch aktivitetstable`)
           }
+
+          setTableMetaData(aktivitetsTable);
     
           const optionField = aktivitetsTable.fields.filter(
             (field: Field) => field.id === 'fldbHk1Ce1Ccw5QvF'
@@ -84,5 +87,5 @@ export const useMetodeverkFetcher = () => {
         }
       }, [metadata])
 
-      return {data, dataError, choices}
+      return {data, dataError, choices, tableMetaData}
 }


### PR DESCRIPTION
Previously we rendered only certain columns. For a more robust solution the columns and rows are rendered by iterating over the data and metadata. The only columns that are hardcoded, are the "system columns": Når, Status and Svar. Likely Svar should be defined by the data from Airtable instead of being hard coded. 

Before:
![bilde](https://github.com/bekk/spire-kk/assets/23199920/49233444-23ac-4529-ba53-de8e7182f680)


After:
![bilde](https://github.com/bekk/spire-kk/assets/23199920/404bb639-5590-4544-88f9-3cdd17985a74)
