### PR TITLE
Filter out metadata table fields after stop column

### DIFF
--- a/backend/src/main/kotlin/no/bekk/AirTableController.kt
+++ b/backend/src/main/kotlin/no/bekk/AirTableController.kt
@@ -30,12 +30,32 @@ class AirTableController {
         }
     }
 
+    private fun filterDataOnStop(metadataResponse: MetadataResponse): MetadataResponse {
+        val newTables = metadataResponse.tables.map { table ->
+            val fields = table.fields
+            if (!fields.isNullOrEmpty()) {
+                val stopIndex = fields.indexOfFirst { it.name == "STOP" }
+                if (stopIndex != -1) {
+                    val newFields = fields.slice(0..< stopIndex)
+                    table.copy(fields = newFields)
+                } else {
+                    table
+                }
+            } else {
+                table
+            }
+        }
+
+        return metadataResponse.copy(tables = newTables)
+    }
+
     suspend fun fetchDataFromMetadata(): MetadataResponse {
 
         val response: HttpResponse = client.get(metadataAddress)
         val responseBody = response.body<String>()
         val metadataResponse: MetadataResponse = json.decodeFromString(responseBody)
-        return metadataResponse
+        val filteredMetaData = filterDataOnStop(metadataResponse = metadataResponse)
+        return filteredMetaData
 
     }
 


### PR DESCRIPTION
Filter out all metadata fields that are after the stop column. Since the frontend only renders out cell values that correspond to the metadata fields which are the table columns, the frontend now only shows data for columns **before** the stop column.

Before:
![image](https://github.com/bekk/spire-kk/assets/23199920/76399163-db20-408b-b82a-ae9507e30710)
![image](https://github.com/bekk/spire-kk/assets/23199920/0a567d1d-008c-43ce-8692-3e67b9606bb9)


After:
![image](https://github.com/bekk/spire-kk/assets/23199920/7a5435f9-cbc7-4c9c-be60-c38bb0441a00)
![image](https://github.com/bekk/spire-kk/assets/23199920/bd1c11fa-4d43-4808-8806-62bd8d595b5f)
