### PR TITLE
Add toast feedback for correct and incorrect answers

### DIFF
--- a/frontend/be-compliant/src/components/answer/Answer.tsx
+++ b/frontend/be-compliant/src/components/answer/Answer.tsx
@@ -1,5 +1,5 @@
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
-import { Select } from '@kvib/react';
+import { Select, useToast } from '@kvib/react';
 import { RecordType } from '../../pages/Table';
 
 export type AnswerType = {
@@ -27,6 +27,8 @@ export const Answer = ({
     answer
   );
 
+  const toast = useToast();
+
   useEffect(() => {
     setSelectedAnswer(answer);
   }, [choices, answer]);
@@ -52,9 +54,24 @@ export const Answer = ({
       if (!response.ok) {
         throw new Error(`Error: ${response.status} ${response.statusText}`);
       }
+      toast({
+        title: 'Suksess',
+        description: "Svaret ditt er lagret",
+        status: 'success',
+        duration: 5000,
+        isClosable: true,
+      })
+
       setFetchNewAnswers(true);
     } catch (error) {
       console.error('There was an error with the submitAnswer request:', error);
+      toast({
+        title: 'Å nei!',
+        description: "Det har skjedd en feil. Prøv på nytt",
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      })
     }
     return;
   };


### PR DESCRIPTION
To give the user feedback about the status of their action after answering a question we added a toast for a successful and unsuccessful answer. 

Before:
![image](https://github.com/bekk/spire-kk/assets/23199920/65ae9aaa-6f62-4a0d-af22-8b293850985e)


After:
![image](https://github.com/bekk/spire-kk/assets/23199920/9b9baa19-2df3-44ed-b006-9e665c9a0898)
![image](https://github.com/bekk/spire-kk/assets/23199920/e13810b8-1b1f-4de7-80e8-eafbe5287c73)
