### PR TITLE
Importer alle fontvekter

### DIFF
--- a/frontend/beCompliant/index.html
+++ b/frontend/beCompliant/index.html
@@ -4,7 +4,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap"
       rel="stylesheet"
     />
     <meta charset="UTF-8" />


### PR DESCRIPTION
**Beskrivelse**

Det er bare standard fontvekt 400 som blir importert, som gjør at tekstene ser veldig annerledes ut avhengig av hvilken nettleser man bruker.

**Løsning**

Importerer alle fontvektene som man kan bruke gjennom Tailwind.


Resolves #875 
