### PR TITLE
fix: Extend cookie lifetime

### DIFF
--- a/backend/src/main/kotlin/no/bekk/authentication/Authentication.kt
+++ b/backend/src/main/kotlin/no/bekk/authentication/Authentication.kt
@@ -36,7 +36,6 @@ fun Application.initializeAuthentication(config: Config, httpClient: HttpClient,
         cookie<UserSession>("user_session") {
             cookie.path = "/"
             cookie.httpOnly = false
-            cookie.maxAgeInSeconds = 60
         }
     }
 


### PR DESCRIPTION
Utvider levetiden til cookies til default, siden SPA-arkitekturen til RR ikke medfører spesielt mye navigasjon hvor cookie blir refreshed.